### PR TITLE
Fix rank command to use DiscordMember

### DIFF
--- a/Source/Commands/Main/RankCommand.cs
+++ b/Source/Commands/Main/RankCommand.cs
@@ -21,10 +21,10 @@ namespace WinBot.Commands.Main
         [Description("Get your current level")]
         [Usage("[user]")]
         [Category(Category.Main)]
-        public async Task Rank(CommandContext Context, [RemainingText]DiscordUser dUser = null)
+        public async Task Rank(CommandContext Context, [RemainingText]DiscordMember dUser)
         {
             if(dUser == null)
-                dUser = Context.User;
+                dUser = Context.Message.Author as DiscordMember;
 
             // Get info
             User user = UserData.GetOrCreateUser(dUser);


### PR DESCRIPTION
Fix rank command to use `DiscordMember` instead of `DiscordUser` to fix stupid API change