### PR TITLE
Replace HTTP command with NetRunner's

### DIFF
--- a/Source/Commands/Fun/HTTPCommand.cs
+++ b/Source/Commands/Fun/HTTPCommand.cs
@@ -1,41 +1,49 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
 
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
 
 using WinBot.Commands.Attributes;
 
-namespace WinBot.Commands.Images
+using Newtonsoft.Json;
+
+namespace WinBot.Commands.Fun
 {
     public class HTTPCommand : BaseCommandModule
     {
         [Command("http")]
-        [Description("Sends a very cute HTTP cat.")]
-        [Usage("[status code]")]
+        [Description("Gets the specified (or random) error code from http.cat")]
         [Category(Category.Fun)]
-        public async Task HTTP(CommandContext Context, string input = "")
+        public async Task HTTP(CommandContext Context, string code = "")
         {
-            bool exists = Array.IndexOf(status_codes, input) != -1;
-            // The extremely long array of HTTP status codes was to
-            // circumvent a bug in which the link would show and the 404 cat
-            // would not show. If you'd rather this happen instead of a bunch of
-            // bloat feel free to remove it. 0 is valid because there is an image.
-            if (string.IsNullOrEmpty(input) || !exists) {
-                await Context.ReplyAsync("https://http.cat/404");
-                return;
+            string url = "";
+			string[] codes = {
+                "100", "101", "102",
+                "200", "201", "202", "203", "204", "206", "207",
+                "300", "301", "302", "303", "304", "305", "307", "308",
+                "400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410", "411", "412", "413", "414", "415", "416", "417", "418", "420", "421", "422", "423", "424", "425", "426", "429", "431", "444", "450", "451", "497", "498", "499",
+                "500", "501", "502", "503", "504", "506", "507", "508", "509", "510", "511", "521", "523", "525", "599"
+            };
+            if (code != "")
+				if (Array.IndexOf(codes, code) != -1) url = $"https://http.cat/{code}";
+                else throw new System.Exception("Invalid HTTP error code!");
+            else {
+                int codeLength = codes.Length - 1;
+                var rand = new Random();
+                int randomCodeIDX = rand.Next(codeLength);
+                code = codes[randomCodeIDX];
+                url = $"https://http.cat/{code}";
             }
-
-            await Context.ReplyAsync($"https://http.cat/{input}");
+            // Send the image in an embed
+            DiscordEmbedBuilder eb = new DiscordEmbedBuilder();
+            eb.WithTitle($"Error {code}");
+            eb.WithColor(new DiscordColor("#ED4245"));
+            eb.WithFooter($"Provided by http.cat");
+            eb.WithImageUrl(url);
+            await Context.RespondAsync("", eb.Build());
         }
-        
-        public static string[] status_codes = {
-            "0",
-            "100", "101", "102",
-            "200", "201", "202", "203", "204", "206", "207",
-            "300", "301", "302", "303", "304", "305", "307", "308",
-            "400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410", "411", "412", "413", "414", "415", "416", "417", "418", "420", "421", "422", "423", "424", "425", "426", "429", "431", "444", "450", "451", "497", "498", "499",
-            "500", "501", "502", "503", "504", "506", "507", "508", "509", "510", "511", "521", "522", "523", "525", "599"
-    	};
     }
 }


### PR DESCRIPTION
Replaces the existing HTTP command with [the command found in NetRunner](https://github.com/nickandfloppy/NetRunner/blob/master/Source/Commands/Fun/HTTPCommand.cs).

## Changes
- No input returns random error code
- Error on invalid code